### PR TITLE
feat: implement analytics page and theme switcher integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@hookform/resolvers": "^5.0.1",
         "@radix-ui/react-label": "^2.1.3",
+        "@radix-ui/react-progress": "^1.1.4",
         "@radix-ui/react-select": "^2.2.0",
         "@radix-ui/react-slot": "^1.2.0",
         "@tailwindcss/vite": "^4.1.4",
@@ -1533,6 +1534,53 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.0.3.tgz",
       "integrity": "sha512-Pf/t/GkndH7CQ8wE2hbkXA+WyZ83fhQQn5DDmwDiDo6AwN/fhaH8oqZ0jRjMrO2iaMhDi6P1HRx6AZwyMinY1g==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-progress/-/react-progress-1.1.4.tgz",
+      "integrity": "sha512-8rl9w7lJdcVPor47Dhws9mUHRHLE+8JEgyJRdNWCpGPa6HIlr3eh+Yn9gyx1CnCLbw5naHsI2gaO9dBWO50vzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-context": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.0"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-progress/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.0.tgz",
+      "integrity": "sha512-/J/FhLdK0zVcILOwt5g+dH4KnkonCtkVJsa2G6JmvbbtZfBEI1gMsO3QMjseL4F/SwfAMt1Vc/0XKYKq+xJ1sw==",
       "license": "MIT",
       "dependencies": {
         "@radix-ui/react-slot": "1.2.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
         "lucide-react": "^0.488.0",
+        "next-themes": "^0.4.6",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-hook-form": "^7.55.0",
@@ -4533,6 +4534,16 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/next-themes": {
+      "version": "0.4.6",
+      "resolved": "https://registry.npmjs.org/next-themes/-/next-themes-0.4.6.tgz",
+      "integrity": "sha512-pZvgD5L0IEvX5/9GWyHMf3m8BKiVQwsCMHfoFosXtXBMnaS0ZnIJ9ST4b4NqLVKDEm8QBxoNNGNaBv2JNF6XNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc"
+      }
     },
     "node_modules/node-releases": {
       "version": "2.0.19",

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "lucide-react": "^0.488.0",
+    "next-themes": "^0.4.6",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-hook-form": "^7.55.0",

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@hookform/resolvers": "^5.0.1",
     "@radix-ui/react-label": "^2.1.3",
+    "@radix-ui/react-progress": "^1.1.4",
     "@radix-ui/react-select": "^2.2.0",
     "@radix-ui/react-slot": "^1.2.0",
     "@tailwindcss/vite": "^4.1.4",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,16 @@
 import { BrowserRouter } from "react-router-dom";
 import { Router } from "./Router";
 import { BudgetProvider } from "./context/budgetContext";
+import { ThemeProvider } from "next-themes";
 
 export function App() {
   return (
-    <BrowserRouter>
-      <BudgetProvider>
-        <Router />
-      </BudgetProvider>
-    </BrowserRouter>
+    <ThemeProvider attribute="class" defaultTheme="system" enableSystem>
+      <BrowserRouter>
+        <BudgetProvider>
+          <Router />
+        </BudgetProvider>
+      </BrowserRouter>
+    </ThemeProvider>
   );
 }

--- a/src/components/BudgetProgressBar.tsx
+++ b/src/components/BudgetProgressBar.tsx
@@ -7,10 +7,10 @@ export function BudgetProgressBar() {
   const spentPercentage = budget > 0 ? (totalExpenses / budget) * 100 : 0;
 
   return (
-    <div className="space-y-2">
+    <div className="space-y-2 w-[300px]">
       <div className="flex justify-between items-center text-sm font-medium">
-        <h1 className="text-xl font-semibold">% of Budget spent</h1>
-        <span className="text-lg">{spentPercentage.toFixed(0)}%</span>
+        <h1 className="text-lg font-semibold">% of Budget spent</h1>
+        <span>{spentPercentage.toFixed(0)}%</span>
       </div>
       <Progress value={spentPercentage} />
     </div>

--- a/src/components/BudgetProgressBar.tsx
+++ b/src/components/BudgetProgressBar.tsx
@@ -7,9 +7,9 @@ export function BudgetProgressBar() {
   const spentPercentage = budget > 0 ? (totalExpenses / budget) * 100 : 0;
 
   return (
-    <div className="space-y-2 w-[300px]">
+    <div className="space-y-2 w-[250px]">
       <div className="flex justify-between items-center text-sm font-medium">
-        <h1 className="text-lg font-semibold">% of Budget spent</h1>
+        <h1 className="font-semibold">% of Budget spent</h1>
         <span>{spentPercentage.toFixed(0)}%</span>
       </div>
       <Progress value={spentPercentage} />

--- a/src/components/BudgetTable.tsx
+++ b/src/components/BudgetTable.tsx
@@ -37,15 +37,15 @@ export function BudgetTable() {
               <TableCell
                 className={`whitespace-nowrap flex items-center justify-center ${
                   transaction.type === "expense"
-                    ? "text-red-700 font-semibold"
-                    : "text-green-700 font-semibold"
+                    ? "text-red-700 dark:text-red-800 font-semibold"
+                    : "text-green-700 dark:text-green-800 font-semibold"
                 }`}
               >
                 <p
                   className={
                     transaction.type === "expense"
-                      ? "bg-red-200 px-1.5 py-0.5 rounded-md"
-                      : "bg-green-200 px-1.5 py-0.5 rounded-md"
+                      ? "dark:bg-red-300 bg-red-200 px-1.5 py-0.5 rounded-md"
+                      : "dark:bg-green-300 bg-green-200 px-1.5 py-0.5 rounded-md"
                   }
                 >
                   {transaction.type}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,5 +1,6 @@
 import { Link } from "react-router-dom";
 import { Button } from "./ui/button";
+import { ThemeSelector } from "./ThemeSelector";
 
 export function Header() {
   return (
@@ -7,9 +8,12 @@ export function Header() {
       <Link to={"/dashboard"}>
         <h3 className="text-2xl text-foreground font-bold">Budget Manager</h3>
       </Link>
-      <Button className="bg-foreground cursor-pointer hover:bg-red-600 transition duration-300">
-        Sign Out
-      </Button>
+      <div className="flex items-center gap-2">
+        <ThemeSelector />
+        <Button className="bg-foreground cursor-pointer hover:bg-destructive transition duration-300">
+          Sign Out
+        </Button>
+      </div>
     </header>
   );
 }

--- a/src/components/HighestTransactionCard.tsx
+++ b/src/components/HighestTransactionCard.tsx
@@ -38,13 +38,13 @@ export function HighestTransactionCard() {
         <ul>
           <li className="flex items-center gap-2">
             Income:
-            <span className="text-green-600 font-semibold text-xl">
+            <span className="text-green-600 dark:text-green-500 font-semibold text-xl">
               ${highestIncome ? highestIncome.amount.toFixed(2) : "N/A"}
             </span>
           </li>
           <li className="flex items-center gap-2">
             Expense:
-            <span className="text-red-600 font-semibold text-xl">
+            <span className="text-red-600 dark:text-red-500 font-semibold text-xl">
               ${highestExpense ? highestExpense.amount.toFixed(2) : "N/A"}
             </span>
           </li>
@@ -55,7 +55,7 @@ export function HighestTransactionCard() {
           highestIncome.amount > highestExpense.amount ? (
             <p>
               Your highest income is{" "}
-              <span className="text-green-600 font-semibold">
+              <span className="text-green-600 dark:text-green-500 font-semibold">
                 {((highestIncome.amount / highestExpense.amount) * 100).toFixed(
                   0
                 )}
@@ -66,7 +66,7 @@ export function HighestTransactionCard() {
           ) : (
             <p>
               Your highest expense is{" "}
-              <span className="text-red-600 font-semibold">
+              <span className="text-red-600 dark:text-red-500 font-semibold">
                 {((highestExpense.amount / highestIncome.amount) * 100).toFixed(
                   0
                 )}

--- a/src/components/HighestTransactionCard.tsx
+++ b/src/components/HighestTransactionCard.tsx
@@ -1,0 +1,86 @@
+import { TrendingUp } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "./ui/card";
+import { useBudgetContext } from "../hooks/useBudgetContext";
+
+export function HighestTransactionCard() {
+  const { transactions } = useBudgetContext();
+
+  const incomeTransactions = transactions.filter((t) => t.type === "income");
+  const expenseTransactions = transactions.filter((t) => t.type === "expense");
+
+  const highestIncome =
+    incomeTransactions.length > 0
+      ? incomeTransactions.reduce((max, curr) =>
+          curr.amount > max.amount ? curr : max
+        )
+      : null;
+
+  const highestExpense =
+    expenseTransactions.length > 0
+      ? expenseTransactions.reduce((max, curr) =>
+          curr.amount > max.amount ? curr : max
+        )
+      : null;
+
+  return (
+    <Card>
+      <CardHeader className="flex items-center justify-between">
+        <CardTitle>Highest transaction per type</CardTitle>
+        <TrendingUp />
+      </CardHeader>
+      <CardContent className="space-y-2">
+        <ul>
+          <li className="flex items-center gap-2">
+            Income:
+            <span className="text-green-600 font-semibold text-xl">
+              ${highestIncome ? highestIncome.amount.toFixed(2) : "N/A"}
+            </span>
+          </li>
+          <li className="flex items-center gap-2">
+            Expense:
+            <span className="text-red-600 font-semibold text-xl">
+              ${highestExpense ? highestExpense.amount.toFixed(2) : "N/A"}
+            </span>
+          </li>
+        </ul>
+      </CardContent>
+      <CardFooter>
+        {highestIncome && highestExpense ? (
+          highestIncome.amount > highestExpense.amount ? (
+            <p>
+              Your highest income is{" "}
+              <span className="text-green-600 font-semibold">
+                {((highestIncome.amount / highestExpense.amount) * 100).toFixed(
+                  0
+                )}
+                %
+              </span>{" "}
+              higher than your highest expense.
+            </p>
+          ) : (
+            <p>
+              Your highest expense is{" "}
+              <span className="text-red-600 font-semibold">
+                {((highestExpense.amount / highestIncome.amount) * 100).toFixed(
+                  0
+                )}
+                %
+              </span>{" "}
+              higher than your highest income.
+            </p>
+          )
+        ) : (
+          <p className="text-muted-foreground italic">
+            Not enough data to compare highest values
+          </p>
+        )}
+      </CardFooter>
+    </Card>
+  );
+}

--- a/src/components/Sidebar.tsx
+++ b/src/components/Sidebar.tsx
@@ -5,6 +5,7 @@ import {
   ChartNoAxesColumn,
 } from "lucide-react";
 import { SidebarItem } from "./SidebarItem";
+import { BudgetProgressBar } from "./BudgetProgressBar";
 
 export function Sidebar() {
   return (
@@ -29,8 +30,8 @@ export function Sidebar() {
           </SidebarItem>
         </ul>
       </nav>
-      <div>
-        <p className="text-xl font-bold">Teste</p>
+      <div className="hidden md:block md:text-left md:pr-12">
+        <BudgetProgressBar />
       </div>
     </div>
   );

--- a/src/components/SidebarItem.tsx
+++ b/src/components/SidebarItem.tsx
@@ -8,7 +8,7 @@ export function SidebarItem({ ...props }: SidebarItemProps) {
   return (
     <Link
       data-current={pathname === props.to}
-      className="flex items-center font-medium text-muted-foreground hover:text-foreground gap-2 cursor-pointer data-[current=true]:text-foreground"
+      className="flex items-center font-medium text-muted-foreground hover:text-foreground gap-2 cursor-pointer data-[current=true]:text-foreground hover:scale-105 transition duration-300"
       {...props}
     />
   );

--- a/src/components/ThemeSelector.tsx
+++ b/src/components/ThemeSelector.tsx
@@ -1,0 +1,35 @@
+import { useTheme } from "next-themes";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "../components/ui/select";
+import { Sun, Moon, Laptop } from "lucide-react";
+
+export function ThemeSelector() {
+  const { setTheme, theme } = useTheme();
+
+  return (
+    <Select onValueChange={setTheme} defaultValue={theme}>
+      <SelectTrigger className="w-[150px]">
+        <SelectValue placeholder="Select theme" />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="light">
+          Light
+          <Sun />
+        </SelectItem>
+        <SelectItem value="dark">
+          Dark
+          <Moon />
+        </SelectItem>
+        <SelectItem value="system">
+          System
+          <Laptop />
+        </SelectItem>
+      </SelectContent>
+    </Select>
+  );
+}

--- a/src/components/TransactionsAverageCard.tsx
+++ b/src/components/TransactionsAverageCard.tsx
@@ -1,0 +1,76 @@
+import { ScrollText } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "./ui/card";
+import { useBudgetContext } from "../hooks/useBudgetContext";
+
+export function TransactionAverageCard() {
+  const { totalIncomes, totalExpenses, transactions } = useBudgetContext();
+
+  const incomeCount = transactions.filter((t) => t.type === "income").length;
+  const expenseCount = transactions.filter((t) => t.type === "expense").length;
+
+  const averageIncomesValue = incomeCount > 0 ? totalIncomes / incomeCount : 0;
+  const averageExpensesValue =
+    expenseCount > 0 ? totalExpenses / expenseCount : 0;
+
+  return (
+    <Card>
+      <CardHeader className="flex items-center justify-between">
+        <CardTitle>Average transaction type value</CardTitle>
+        <ScrollText />
+      </CardHeader>
+      <CardContent>
+        <ul>
+          <li className="flex items-center gap-2">
+            Income:
+            <span className="text-green-600 font-semibold text-xl">
+              ${averageIncomesValue.toFixed(2)}
+            </span>
+          </li>
+          <li className="flex items-center gap-2">
+            Expense:
+            <span className="text-red-600 font-semibold text-xl">
+              ${averageExpensesValue.toFixed(2)}
+            </span>
+          </li>
+        </ul>
+      </CardContent>
+      <CardFooter>
+        {averageIncomesValue > 0 && averageExpensesValue > 0 ? (
+          averageIncomesValue > averageExpensesValue ? (
+            <p>
+              Your average incomes value is{" "}
+              <span className="text-green-600 font-semibold">
+                {((averageIncomesValue / averageExpensesValue) * 100).toFixed(
+                  0
+                )}
+                %
+              </span>{" "}
+              higher than your expenses
+            </p>
+          ) : (
+            <p>
+              Your average expenses value is{" "}
+              <span className="text-red-600 font-semibold">
+                {((averageExpensesValue / averageIncomesValue) * 100).toFixed(
+                  0
+                )}
+                %
+              </span>{" "}
+              higher than your incomes
+            </p>
+          )
+        ) : (
+          <p className="text-muted-foreground italic">
+            Not enough data to compare averages
+          </p>
+        )}
+      </CardFooter>
+    </Card>
+  );
+}

--- a/src/components/TransactionsAverageCard.tsx
+++ b/src/components/TransactionsAverageCard.tsx
@@ -51,7 +51,7 @@ export function TransactionAverageCard() {
                 )}
                 %
               </span>{" "}
-              higher than your expenses
+              higher than your average expense value
             </p>
           ) : (
             <p>
@@ -62,7 +62,7 @@ export function TransactionAverageCard() {
                 )}
                 %
               </span>{" "}
-              higher than your incomes
+              higher than your average income value
             </p>
           )
         ) : (

--- a/src/components/TransactionsAverageCard.tsx
+++ b/src/components/TransactionsAverageCard.tsx
@@ -28,13 +28,13 @@ export function TransactionAverageCard() {
         <ul>
           <li className="flex items-center gap-2">
             Income:
-            <span className="text-green-600 font-semibold text-xl">
+            <span className="text-green-600 dark:text-green-500 font-semibold text-xl">
               ${averageIncomesValue.toFixed(2)}
             </span>
           </li>
           <li className="flex items-center gap-2">
             Expense:
-            <span className="text-red-600 font-semibold text-xl">
+            <span className="text-red-600 dark:text-red-500 font-semibold text-xl">
               ${averageExpensesValue.toFixed(2)}
             </span>
           </li>
@@ -45,7 +45,7 @@ export function TransactionAverageCard() {
           averageIncomesValue > averageExpensesValue ? (
             <p>
               Your average incomes value is{" "}
-              <span className="text-green-600 font-semibold">
+              <span className="text-green-600 dark:text-green-500 font-semibold">
                 {((averageIncomesValue / averageExpensesValue) * 100).toFixed(
                   0
                 )}
@@ -56,7 +56,7 @@ export function TransactionAverageCard() {
           ) : (
             <p>
               Your average expenses value is{" "}
-              <span className="text-red-600 font-semibold">
+              <span className="text-red-600 dark:text-red-500 font-semibold">
                 {((averageExpensesValue / averageIncomesValue) * 100).toFixed(
                   0
                 )}

--- a/src/components/TransactionsCountCard.tsx
+++ b/src/components/TransactionsCountCard.tsx
@@ -24,13 +24,13 @@ export function TransactionCountCard() {
         <ul>
           <li className="flex items-center gap-2">
             Income:
-            <span className="text-green-600 font-semibold text-xl">
+            <span className="text-green-600 dark:text-green-500 font-semibold text-xl">
               {incomeCount}
             </span>
           </li>
           <li className="flex items-center gap-2">
             Expense:
-            <span className="text-red-600 font-semibold text-xl">
+            <span className="text-red-600 dark:text-red-500 font-semibold text-xl">
               {expenseCount}
             </span>
           </li>
@@ -41,7 +41,7 @@ export function TransactionCountCard() {
           incomeCount > expenseCount ? (
             <p>
               You have{" "}
-              <span className="text-green-600 font-semibold">
+              <span className="text-green-600 dark:text-green-500 font-semibold">
                 {((incomeCount / expenseCount) * 100 - 100).toFixed(0)}%
               </span>{" "}
               more income transactions than expenses.
@@ -49,7 +49,7 @@ export function TransactionCountCard() {
           ) : (
             <p>
               You have{" "}
-              <span className="text-red-600 font-semibold">
+              <span className="text-red-600 dark:text-red-500 font-semibold">
                 {((expenseCount / incomeCount) * 100 - 100).toFixed(0)}%
               </span>{" "}
               more expense transactions than incomes.

--- a/src/components/TransactionsCountCard.tsx
+++ b/src/components/TransactionsCountCard.tsx
@@ -42,7 +42,7 @@ export function TransactionCountCard() {
             <p>
               You have{" "}
               <span className="text-green-600 font-semibold">
-                {((incomeCount / expenseCount) * 100).toFixed(0)}%
+                {((incomeCount / expenseCount) * 100 - 100).toFixed(0)}%
               </span>{" "}
               more income transactions than expenses.
             </p>
@@ -50,7 +50,7 @@ export function TransactionCountCard() {
             <p>
               You have{" "}
               <span className="text-red-600 font-semibold">
-                {((expenseCount / incomeCount) * 100).toFixed(0)}%
+                {((expenseCount / incomeCount) * 100 - 100).toFixed(0)}%
               </span>{" "}
               more expense transactions than incomes.
             </p>

--- a/src/components/TransactionsCountCard.tsx
+++ b/src/components/TransactionsCountCard.tsx
@@ -1,0 +1,66 @@
+import { ListOrdered } from "lucide-react";
+import {
+  Card,
+  CardContent,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from "./ui/card";
+import { useBudgetContext } from "../hooks/useBudgetContext";
+
+export function TransactionCountCard() {
+  const { transactions } = useBudgetContext();
+
+  const incomeCount = transactions.filter((t) => t.type === "income").length;
+  const expenseCount = transactions.filter((t) => t.type === "expense").length;
+
+  return (
+    <Card>
+      <CardHeader className="flex items-center justify-between">
+        <CardTitle>Transaction count by type</CardTitle>
+        <ListOrdered />
+      </CardHeader>
+      <CardContent>
+        <ul>
+          <li className="flex items-center gap-2">
+            Income:
+            <span className="text-green-600 font-semibold text-xl">
+              {incomeCount}
+            </span>
+          </li>
+          <li className="flex items-center gap-2">
+            Expense:
+            <span className="text-red-600 font-semibold text-xl">
+              {expenseCount}
+            </span>
+          </li>
+        </ul>
+      </CardContent>
+      <CardFooter>
+        {incomeCount > 0 && expenseCount > 0 ? (
+          incomeCount > expenseCount ? (
+            <p>
+              You have{" "}
+              <span className="text-green-600 font-semibold">
+                {((incomeCount / expenseCount) * 100).toFixed(0)}%
+              </span>{" "}
+              more income transactions than expenses.
+            </p>
+          ) : (
+            <p>
+              You have{" "}
+              <span className="text-red-600 font-semibold">
+                {((expenseCount / incomeCount) * 100).toFixed(0)}%
+              </span>{" "}
+              more expense transactions than incomes.
+            </p>
+          )
+        ) : (
+          <p className="text-muted-foreground italic">
+            Not enough data to compare transactions
+          </p>
+        )}
+      </CardFooter>
+    </Card>
+  );
+}

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -1,0 +1,92 @@
+import * as React from "react"
+
+import { cn } from "@/lib/utils"
+
+function Card({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card"
+      className={cn(
+        "bg-card text-card-foreground flex flex-col gap-6 rounded-xl border py-6 shadow-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-header"
+      className={cn(
+        "@container/card-header grid auto-rows-min grid-rows-[auto_auto] items-start gap-1.5 px-6 has-data-[slot=card-action]:grid-cols-[1fr_auto] [.border-b]:pb-6",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-title"
+      className={cn("leading-none font-semibold", className)}
+      {...props}
+    />
+  )
+}
+
+function CardDescription({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-description"
+      className={cn("text-muted-foreground text-sm", className)}
+      {...props}
+    />
+  )
+}
+
+function CardAction({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-action"
+      className={cn(
+        "col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CardContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-content"
+      className={cn("px-6", className)}
+      {...props}
+    />
+  )
+}
+
+function CardFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="card-footer"
+      className={cn("flex items-center px-6 [.border-t]:pt-6", className)}
+      {...props}
+    />
+  )
+}
+
+export {
+  Card,
+  CardHeader,
+  CardFooter,
+  CardTitle,
+  CardAction,
+  CardDescription,
+  CardContent,
+}

--- a/src/lib/charts/BarChart.tsx
+++ b/src/lib/charts/BarChart.tsx
@@ -1,0 +1,52 @@
+import {
+  BarChart,
+  Bar,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  Cell,
+} from "recharts";
+
+interface BarChartData {
+  name: string;
+  value: number;
+}
+
+interface TinyBarChartProps {
+  data: BarChartData[];
+}
+
+export function TinyBarChart({ data }: TinyBarChartProps) {
+  const filteredData = data.filter((item) => item.value > 0);
+
+  if (filteredData.length === 0) {
+    return (
+      <div className="border border-border bg-muted rounded-md h-[300px] flex items-center justify-center">
+        <p className="text-accent-foreground opacity-50 font-semibold">
+          No data available
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="border border-border bg-muted rounded-md">
+      <ResponsiveContainer width="100%" height={400}>
+        <BarChart data={filteredData}>
+          <XAxis dataKey="name" />
+          <Tooltip />
+          <Bar dataKey="value" radius={[6, 6, 0, 0]}>
+            {filteredData.map((entry, index) => {
+              let fillColor = "#ccc";
+              if (entry.name === "Budget") fillColor = "#0088FE";
+              else if (entry.name === "Expense") fillColor = "#d31616";
+              else if (entry.name === "Income") fillColor = "#00da41";
+
+              return <Cell key={`cell-${index}`} fill={fillColor} />;
+            })}
+          </Bar>
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}

--- a/src/pages/analytics.tsx
+++ b/src/pages/analytics.tsx
@@ -1,9 +1,22 @@
+import { useBudgetContext } from "../hooks/useBudgetContext";
+import { TinyBarChart } from "../lib/charts/BarChart";
+
 export function Analytics() {
+  const { budget, totalIncomes, totalExpenses } = useBudgetContext();
+
+  const data = [
+    { name: "Budget", value: budget },
+    { name: "Income", value: totalIncomes },
+    { name: "Expense", value: totalExpenses },
+  ];
+
   return (
     <div>
       <h1 className="text-3xl font-semibold">Analytics</h1>
       <main className="flex flex-col gap-16 p-4">
-        <div className="mt-4"></div>
+        <div className="mt-4">
+          <TinyBarChart data={data} />
+        </div>
         <div className="flex flex-col gap-4">
           <h2 className="text-xl font-semibold">Insights</h2>
           <div className="grid grid-cols-3 gap-4"></div>

--- a/src/pages/analytics.tsx
+++ b/src/pages/analytics.tsx
@@ -1,3 +1,6 @@
+import { HighestTransactionCard } from "../components/HighestTransactionCard";
+import { TransactionAverageCard } from "../components/TransactionsAverageCard";
+import { TransactionCountCard } from "../components/TransactionsCountCard";
 import { useBudgetContext } from "../hooks/useBudgetContext";
 import { TinyBarChart } from "../lib/charts/BarChart";
 
@@ -19,7 +22,11 @@ export function Analytics() {
         </div>
         <div className="flex flex-col gap-4">
           <h2 className="text-xl font-semibold">Insights</h2>
-          <div className="grid grid-cols-3 gap-4"></div>
+          <div className="grid grid-cols-3 gap-4">
+            <TransactionAverageCard />
+            <TransactionCountCard />
+            <HighestTransactionCard />
+          </div>
         </div>
       </main>
     </div>

--- a/src/pages/analytics.tsx
+++ b/src/pages/analytics.tsx
@@ -1,3 +1,14 @@
 export function Analytics() {
-  return <h1>Analytics</h1>;
+  return (
+    <div>
+      <h1 className="text-3xl font-semibold">Analytics</h1>
+      <main className="flex flex-col gap-16 p-4">
+        <div className="mt-4"></div>
+        <div className="flex flex-col gap-4">
+          <h2 className="text-xl font-semibold">Insights</h2>
+          <div className="grid grid-cols-3 gap-4"></div>
+        </div>
+      </main>
+    </div>
+  );
 }

--- a/src/pages/dashboard.tsx
+++ b/src/pages/dashboard.tsx
@@ -3,6 +3,9 @@ import { useBudgetContext } from "../hooks/useBudgetContext";
 import { BudgetPieChart } from "../lib/charts/BudgetPieChart";
 import { BudgetTable } from "../components/BudgetTable";
 import { BudgetProgressBar } from "../components/BudgetProgressBar";
+import { Button } from "../components/ui/button";
+import { CirclePlus } from "lucide-react";
+import { useNavigate } from "react-router-dom";
 
 export function Dashboard() {
   const {
@@ -13,6 +16,8 @@ export function Dashboard() {
     totalIncomes,
     totalExpenses,
   } = useBudgetContext();
+
+  const navigate = useNavigate();
 
   useEffect(() => {
     handleGetCurrentBudget();
@@ -39,12 +44,21 @@ export function Dashboard() {
             <BudgetPieChart data={data} />
           </div>
           <div className="flex flex-col gap-4 flex-1">
-            <h2 className="text-xl font-semibold">Your transactions</h2>
+            <div className="flex items-center justify-between">
+              <h2 className="text-xl font-semibold">Your transactions</h2>
+              <Button
+                className="cursor-pointer"
+                onClick={() => navigate("/transactions")}
+              >
+                <CirclePlus />
+                Add new transaction
+              </Button>
+            </div>
             <BudgetTable />
           </div>
         </main>
       </div>
-      <div className="md:max-w-2xl">
+      <div className="block md:hidden">
         <BudgetProgressBar />
       </div>
     </div>


### PR DESCRIPTION
This PR introduces the new Analytics page featuring charts and insight cards based on the user's transactions. It also adds global theme switching support (light/dark/system) using next-themes and the Select component from shadcn/ui.


- Created the /analytics page with: TinyBarChart component for visualizing budget data. Insight cards: Average transaction value (TransactionsAverageCard), Highest transaction (HighestTransactionCard), Total number of transactions (TransactionsCountCard).
- Fixed styles and logic in existing components.
- Integrated ThemeProvider with next-themes.
- Created ThemeSelector component using shadcn/ui.
- Added ThemeSelector to the Header component.
- Adjusted styles to fully support dark mode.