### PR TITLE
feat: add localStorage persistence to budget and transactions in BudgetContext

### DIFF
--- a/src/context/budgetContext.tsx
+++ b/src/context/budgetContext.tsx
@@ -1,4 +1,4 @@
-import { createContext, ReactNode, useState } from "react";
+import { createContext, ReactNode, useEffect, useState } from "react";
 import { Transaction } from "../types/transactions";
 import { addNewRowToSheet, removeRowFromSheet } from "../utils/sheets";
 
@@ -23,9 +23,18 @@ interface BudgetProviderProps {
 }
 
 export function BudgetProvider({ children }: BudgetProviderProps) {
-  const [transactions, setTransactions] = useState<Transaction[]>([]);
-  const [budget, setBudget] = useState(0);
-  const [currentBudget, setCurrentBudget] = useState(0);
+  const [transactions, setTransactions] = useState<Transaction[]>(
+    JSON.parse(localStorage.getItem("transactions") || "[]")
+  );
+  const [budget, setBudget] = useState<number>(
+    JSON.parse(localStorage.getItem("budget") || "0")
+  );
+  const [currentBudget, setCurrentBudget] = useState<number>(0);
+
+  useEffect(() => {
+    localStorage.setItem("transactions", JSON.stringify(transactions));
+    localStorage.setItem("budget", JSON.stringify(budget));
+  }, [transactions, budget]);
 
   const totalIncomes = transactions
     .filter((t) => t.type === "income")


### PR DESCRIPTION
This PR adds localStorage support to persist the budget and transactions data in the BudgetContext.
On initial load, it retrieves the saved data (if any) from localStorage and uses it to initialize the state.
Any updates to the budget or transactions are automatically saved to localStorage to ensure persistence across page reloads.

Without this, all budget and transaction data would be lost on page refresh. Persisting this data improves the user experience and ensures continuity of information between sessions.